### PR TITLE
Remove development only files from Composer archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Remove files for archives generated using `git archive`
+build/ export-ignore
+demo_shop/ export-ignore
+tests/ export-ignore
+
+.gitattributes export-ignore
+.gitignore export-ignore
+.hgignore export-ignore
+build.sh export-ignore
+CHANGELOG.md export-ignore
+phpunit.xml export-ignore
+/WebToPay.php export-ignore
+src/includes.php export-ignore


### PR DESCRIPTION
Many files are unnecessary when installing with Composer.

Install size is reduced from 1 MB to 80 KB.

Root `WebToPay.php` has copy of each class and confuses IDE, Composer will autoload from `src/` anyway.

Other files are useless in production and only inflates install size.

