### PR TITLE
http_build_query deprecated null

### DIFF
--- a/src/WebToPay.php
+++ b/src/WebToPay.php
@@ -197,13 +197,13 @@ class WebToPay {
             }
 
             if ($logFile) {
-                self::log('OK', http_build_query($data, null, '&'), $logFile);
+                self::log('OK', http_build_query($data, '', '&'), $logFile);
             }
             return $data;
 
         } catch (WebToPayException $exception) {
         	if ($logFile && $exception->getCode() != WebToPayException::E_DEPRECATED_USAGE) {
-                self::log('ERR', $exception . "\nQuery: " . http_build_query($query, null, '&'), $logFile);
+                self::log('ERR', $exception . "\nQuery: " . http_build_query($query, '', '&'), $logFile);
             }
             throw $exception;
         }

--- a/src/WebToPay/RequestBuilder.php
+++ b/src/WebToPay/RequestBuilder.php
@@ -158,7 +158,7 @@ class WebToPay_RequestBuilder {
      * @return array
      */
     protected function createRequest(array $request) {
-        $data = $this->util->encodeSafeUrlBase64(http_build_query($request, null, '&'));
+        $data = $this->util->encodeSafeUrlBase64(http_build_query($request, '', '&'));
         return array(
             'data' => $data,
             'sign' => md5($data . $this->projectPassword),

--- a/src/WebToPay/UrlBuilder.php
+++ b/src/WebToPay/UrlBuilder.php
@@ -86,7 +86,7 @@ class WebToPay_UrlBuilder {
      * @return string
      */
     protected function createUrlFromRequestAndLanguage($request) {
-        $url = $this->getPaymentUrl() . '?' . http_build_query($request, null, '&');
+        $url = $this->getPaymentUrl() . '?' . http_build_query($request, '', '&');
         return preg_replace('/[\r\n]+/is', '', $url);
     }
 

--- a/src/WebToPay/WebClient.php
+++ b/src/WebToPay/WebClient.php
@@ -19,7 +19,7 @@ class WebToPay_WebClient {
     public function get($uri, array $queryData = array()) {
         if (count($queryData) > 0) {
             $uri .= strpos($uri, '?') === false ? '?' : '&';
-            $uri .= http_build_query($queryData, null, '&');
+            $uri .= http_build_query($queryData, '', '&');
         }
         $url = parse_url($uri);
         if ('https' == $url['scheme']) {


### PR DESCRIPTION
in http_build_query null as numeric_prefix is deprecated and shows errors. Having '' and not null doesn't show errors and works from PHP5.1.5 to PHP8.1.3 versions.
From what I tested, newest php version doesn't want numeric_prefix as null an shows error.