### PR TITLE
BUGFIX - payment methods provider filters fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 Version history
 ===============
+Version 3.0.2   - 2024-07-17
+
+    * Nullable payment methods filter `amount` should be treated as absent on `null`
+    * Nullable payment method filter `currency` did not work with `null` value anyway so it does not accept it anymore
+
 Version 3.0.0   - 2024-04-30
 
     * increased minimal PHP version to 7.4

--- a/src/WebToPay/PaymentMethodListProvider.php
+++ b/src/WebToPay/PaymentMethodListProvider.php
@@ -48,11 +48,11 @@ class WebToPay_PaymentMethodListProvider
      *
      * @throws WebToPayException
      */
-    public function getPaymentMethodList(?float $amount, ?string $currency): WebToPay_PaymentMethodList
+    public function getPaymentMethodList(?float $amount, string $currency): WebToPay_PaymentMethodList
     {
         if (!isset($this->methodListCache[$currency])) {
             $xmlAsString = $this->webClient->get(
-                $this->urlBuilder->buildForPaymentsMethodList($this->projectId, (string) $amount, $currency)
+                $this->urlBuilder->buildForPaymentsMethodList($this->projectId, $amount, $currency)
             );
             $useInternalErrors = libxml_use_internal_errors(false);
             $rootNode = simplexml_load_string($xmlAsString);

--- a/src/WebToPay/UrlBuilder.php
+++ b/src/WebToPay/UrlBuilder.php
@@ -54,11 +54,16 @@ class WebToPay_UrlBuilder
     /**
      * Builds a complete URL for payment list API
      */
-    public function buildForPaymentsMethodList(int $projectId, ?string $amount, ?string $currency): string
+    public function buildForPaymentsMethodList(int $projectId, ?float $amount, string $currency): string
     {
         $route = $this->environmentSettings['paymentMethodList'];
 
-        return $route . $projectId . '/currency:' . $currency . '/amount:' . $amount;
+        $filters = ['/currency:' . $currency];
+        if ($amount !== null) {
+            $filters[] = '/amount:' . $amount;
+        }
+
+        return $route . $projectId . implode('', $filters);
     }
 
     /**

--- a/tests/StaticMethods/WebToPayTest.php
+++ b/tests/StaticMethods/WebToPayTest.php
@@ -148,9 +148,9 @@ class StaticMethods_WebToPayCase extends AbstractTestCase
             'currency' => 'EUR',
         ];
 
-        yield 'currency is null' => [
+        yield 'amount is not null' => [
             'amount' => 1000,
-            'currency' => null,
+            'currency' => 'EUR',
         ];
     }
 
@@ -161,7 +161,7 @@ class StaticMethods_WebToPayCase extends AbstractTestCase
      * @throws WebToPay_Exception_Callback
      * @throws WebToPay_Exception_Configuration
      */
-    public function testGetPaymentMethodList(?int $amount, ?string $currency): void
+    public function testGetPaymentMethodList(?int $amount, string $currency): void
     {
         $paymentMethodListProviderMock = $this->createMock(WebToPay_PaymentMethodListProvider::class);
         $paymentMethodListProviderMock->expects($this->once())

--- a/tests/WebToPay/PaymentMethodListProviderTest.php
+++ b/tests/WebToPay/PaymentMethodListProviderTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+class PaymentMethodListProviderTest extends TestCase
+{
+    /**
+     * @dataProvider dataProviderGetPaymentMethodListForExpectedUrl
+     */
+    public function testGetPaymentMethodListForExpectedUrl(
+        string $expectedUrl,
+        int $projectId,
+        ?int $amount,
+        string $currency
+    ): void {
+        $webClient = $this->createMock(WebToPay_WebClient::class);
+        $urlBuilder = new WebToPay_UrlBuilder(
+            [
+                'routes' => [
+                    'test' => [
+                        'paymentMethodList' => 'https://www.paysera.com/new/api/paymentMethods/',
+                    ],
+                ],
+            ],
+            'test'
+        );
+
+        $provider = new WebToPay_PaymentMethodListProvider(
+            $projectId,
+            $webClient,
+            $urlBuilder
+        );
+
+        $webClient->expects($this->once())->method('get')->with($expectedUrl)->willReturn(
+            file_get_contents(dirname(__DIR__) . '/Functional/data/payment-methods.xml')
+        );
+
+        $provider->getPaymentMethodList($amount, $currency);
+    }
+
+    public function dataProviderGetPaymentMethodListForExpectedUrl(): array
+    {
+        return [
+            [
+                'https://www.paysera.com/new/api/paymentMethods/6028/currency:USD/amount:0',
+                6028,
+                0,
+                'USD',
+            ],
+            [
+                'https://www.paysera.com/new/api/paymentMethods/6028/currency:EUR/amount:1000000',
+                6028,
+                1000000,
+                'EUR',
+            ],
+            [
+                'https://www.paysera.com/new/api/paymentMethods/6028/currency:EUR',
+                6028,
+                null,
+                'EUR',
+            ],
+        ];
+    }
+}

--- a/tests/WebToPay/UrlBuilderTest.php
+++ b/tests/WebToPay/UrlBuilderTest.php
@@ -40,28 +40,22 @@ class WebToPay_UrlBuilderTest extends TestCase
     public function getDataForTestingBuildForPaymentsMethodList(): iterable
     {
         yield 'amount is not null; currency is not null' => [
-            'amount' => '1.00',
+            'amount' => 100,
             'currency' => 'EUR',
-            'expectedUrl' => 'https://sandbox.paysera.com/new/api/paymentMethods/1/currency:EUR/amount:1.00',
+            'expectedUrl' => 'https://sandbox.paysera.com/new/api/paymentMethods/1/currency:EUR/amount:100',
         ];
 
         yield 'amount is null; currency is not null' => [
             'amount' => null,
             'currency' => 'EUR',
-            'expectedUrl' => 'https://sandbox.paysera.com/new/api/paymentMethods/1/currency:EUR/amount:',
-        ];
-
-        yield 'amount is not null; currency is null' => [
-            'amount' => '1.00',
-            'currency' => null,
-            'expectedUrl' => 'https://sandbox.paysera.com/new/api/paymentMethods/1/currency:/amount:1.00',
+            'expectedUrl' => 'https://sandbox.paysera.com/new/api/paymentMethods/1/currency:EUR',
         ];
     }
 
     /**
      * @dataProvider getDataForTestingBuildForPaymentsMethodList
      */
-    public function testBuildForPaymentsMethodList(?string $amount, ?string $currency, string $expectedUrl)
+    public function testBuildForPaymentsMethodList(?float $amount, ?string $currency, string $expectedUrl)
     {
         $url = $this->urlBuilder->buildForPaymentsMethodList(1, $amount, $currency);
 


### PR DESCRIPTION
* Payment methods provider fix.

`null` amount when searching for payment methods was treated as 0 so it did not return any payment methods. I think, it should return all enabled project payment methods instead.  Null currency did not work, no point to allow searching by it. 

Fixed both issues, yet I suggest adapting my PR according your standards. It's quite strange that resulting file WebToPay.php got so different for me...

Issue demonstration:

```
erikas@zen:~/Projects/test$ cat test.php 
<?php

require_once 'WebToPay.php';


explainResult(WebToPay::getPaymentMethodList(6028, null, 'EUR'));
explainResult(WebToPay::getPaymentMethodList(6028, 0, 'EUR'));
explainResult(WebToPay::getPaymentMethodList(6028, 100, 'EUR'));
explainResult(WebToPay::getPaymentMethodList(6028, 100, null));

function explainResult(WebToPay_PaymentMethodList $list): void
{
    printf("LT payment methods found: %d\n", count((array) $list->getCountry('lt')?->getPaymentMethods()));
}
erikas@zen:~/Projects/test$ php test.php #before my changes
LT payment methods found: 0
LT payment methods found: 0
LT payment methods found: 13
PHP Fatal error:  Uncaught TypeError: WebToPay_PaymentMethodList::__construct(): Argument #2 ($currency) must be of type string, null given, called in /home/erikas/Projects/test/WebToPay.php on line 1557 and defined in /home/erikas/Projects/test/WebToPay.php:1258
Stack trace:
#0 /home/erikas/Projects/test/WebToPay.php(1557): WebToPay_PaymentMethodList->__construct()
#1 /home/erikas/Projects/test/WebToPay.php(253): WebToPay_PaymentMethodListProvider->getPaymentMethodList()
#2 /home/erikas/Projects/test/test.php(9): WebToPay::getPaymentMethodList()
#3 {main}
  thrown in /home/erikas/Projects/test/WebToPay.php on line 1258

erikas@zen:~/Projects/test$ php test.php #after my changes
LT payment methods found: 16
LT payment methods found: 0
LT payment methods found: 13
PHP Fatal error:  Uncaught TypeError: WebToPay_PaymentMethodListProvider::getPaymentMethodList(): Argument #2 ($currency) must be of type string, null given, called in /home/erikas/Projects/test/WebToPay.php on line 253 and defined in /home/erikas/Projects/test/WebToPay.php:1082
Stack trace:
#0 /home/erikas/Projects/test/WebToPay.php(253): WebToPay_PaymentMethodListProvider->getPaymentMethodList()
#1 /home/erikas/Projects/test/test.php(9): WebToPay::getPaymentMethodList()
#2 {main}
  thrown in /home/erikas/Projects/test/WebToPay.php on line 1082
erikas@zen:~/Projects/test$
```