### PR TITLE
bugfix - no more empty payment method list if filter "amount" is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Version history
 ===============
+Version 3.0.2   - 2024-07-18
+
+    * payment method list provider with amount=null will not filter by amount(=0) anymore
+
 Version 3.0.0   - 2024-04-30
 
     * increased minimal PHP version to 7.4

--- a/WebToPay.php
+++ b/WebToPay.php
@@ -1545,7 +1545,7 @@ class WebToPay_PaymentMethodListProvider
     {
         if (!isset($this->methodListCache[$currency])) {
             $xmlAsString = $this->webClient->get(
-                $this->urlBuilder->buildForPaymentsMethodList($this->projectId, (string) $amount, $currency)
+                $this->urlBuilder->buildForPaymentsMethodList($this->projectId, $amount, $currency)
             );
             $useInternalErrors = libxml_use_internal_errors(false);
             $rootNode = simplexml_load_string($xmlAsString);
@@ -1856,11 +1856,21 @@ class WebToPay_UrlBuilder
     /**
      * Builds a complete URL for payment list API
      */
-    public function buildForPaymentsMethodList(int $projectId, ?string $amount, ?string $currency): string
+    public function buildForPaymentsMethodList(int $projectId, ?float $amount, ?string $currency): string
     {
         $route = $this->environmentSettings['paymentMethodList'];
 
-        return $route . $projectId . '/currency:' . $currency . '/amount:' . $amount;
+        $filters = ['currency' => $currency];
+        if ($amount !== null) {
+            $filters['amount'] = $amount;
+        }
+
+        $queryParts = [];
+        foreach ($filters as $key => $value) {
+            $queryParts[] = sprintf('/%s:%s', $key, $value);
+        }
+
+        return $route . $projectId . implode('', $queryParts);
     }
 
     /**

--- a/WebToPay.php
+++ b/WebToPay.php
@@ -26,7 +26,7 @@ declare(strict_types=1);
  * @package    WebToPay
  * @author     EVP International
  * @license    http://www.gnu.org/licenses/lgpl.html
- * @version    3.0.1
+ * @version    3.0.2
  * @link       http://www.webtopay.com/
  */
 
@@ -38,7 +38,7 @@ class WebToPay
     /**
      * WebToPay Library version.
      */
-    public const VERSION = '3.0.1';
+    public const VERSION = '3.0.2';
 
     /**
      * Server URL where all requests should go.

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "webtopay/libwebtopay",
     "description": "PHP Library for Paysera payment gateway integration",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "license": "LGPL-3.0",
     "authors": [
         {

--- a/src/WebToPay.php
+++ b/src/WebToPay.php
@@ -22,7 +22,7 @@ declare(strict_types=1);
  * @package    WebToPay
  * @author     EVP International
  * @license    http://www.gnu.org/licenses/lgpl.html
- * @version    3.0.1
+ * @version    3.0.2
  * @link       http://www.webtopay.com/
  */
 
@@ -34,7 +34,7 @@ class WebToPay
     /**
      * WebToPay Library version.
      */
-    public const VERSION = '3.0.1';
+    public const VERSION = '3.0.2';
 
     /**
      * Server URL where all requests should go.

--- a/src/WebToPay/PaymentMethodListProvider.php
+++ b/src/WebToPay/PaymentMethodListProvider.php
@@ -52,7 +52,7 @@ class WebToPay_PaymentMethodListProvider
     {
         if (!isset($this->methodListCache[$currency])) {
             $xmlAsString = $this->webClient->get(
-                $this->urlBuilder->buildForPaymentsMethodList($this->projectId, (string) $amount, $currency)
+                $this->urlBuilder->buildForPaymentsMethodList($this->projectId, $amount, $currency)
             );
             $useInternalErrors = libxml_use_internal_errors(false);
             $rootNode = simplexml_load_string($xmlAsString);

--- a/src/WebToPay/UrlBuilder.php
+++ b/src/WebToPay/UrlBuilder.php
@@ -54,11 +54,21 @@ class WebToPay_UrlBuilder
     /**
      * Builds a complete URL for payment list API
      */
-    public function buildForPaymentsMethodList(int $projectId, ?string $amount, ?string $currency): string
+    public function buildForPaymentsMethodList(int $projectId, ?float $amount, ?string $currency): string
     {
         $route = $this->environmentSettings['paymentMethodList'];
 
-        return $route . $projectId . '/currency:' . $currency . '/amount:' . $amount;
+        $filters = ['currency' => $currency];
+        if ($amount !== null) {
+            $filters['amount'] = $amount;
+        }
+
+        $queryParts = [];
+        foreach ($filters as $key => $value) {
+            $queryParts[] = sprintf('/%s:%s', $key, $value);
+        }
+
+        return $route . $projectId . implode('', $queryParts);
     }
 
     /**

--- a/tests/WebToPay/UrlBuilderTest.php
+++ b/tests/WebToPay/UrlBuilderTest.php
@@ -40,28 +40,28 @@ class WebToPay_UrlBuilderTest extends TestCase
     public function getDataForTestingBuildForPaymentsMethodList(): iterable
     {
         yield 'amount is not null; currency is not null' => [
-            'amount' => '1.00',
+            'amount' => 1.1,
             'currency' => 'EUR',
-            'expectedUrl' => 'https://sandbox.paysera.com/new/api/paymentMethods/1/currency:EUR/amount:1.00',
+            'expectedUrl' => 'https://sandbox.paysera.com/new/api/paymentMethods/1/currency:EUR/amount:1.1',
         ];
 
         yield 'amount is null; currency is not null' => [
             'amount' => null,
             'currency' => 'EUR',
-            'expectedUrl' => 'https://sandbox.paysera.com/new/api/paymentMethods/1/currency:EUR/amount:',
+            'expectedUrl' => 'https://sandbox.paysera.com/new/api/paymentMethods/1/currency:EUR',
         ];
 
         yield 'amount is not null; currency is null' => [
-            'amount' => '1.00',
+            'amount' => 1.0,
             'currency' => null,
-            'expectedUrl' => 'https://sandbox.paysera.com/new/api/paymentMethods/1/currency:/amount:1.00',
+            'expectedUrl' => 'https://sandbox.paysera.com/new/api/paymentMethods/1/currency:/amount:1',
         ];
     }
 
     /**
      * @dataProvider getDataForTestingBuildForPaymentsMethodList
      */
-    public function testBuildForPaymentsMethodList(?string $amount, ?string $currency, string $expectedUrl)
+    public function testBuildForPaymentsMethodList(?float $amount, ?string $currency, string $expectedUrl)
     {
         $url = $this->urlBuilder->buildForPaymentsMethodList(1, $amount, $currency);
 


### PR DESCRIPTION
After upgrading library from 1.* to 3.* version for our company I noticed a big annoying problem - can not fetch all enabled payment  methods anymore. :( Script to illustrate a problem:

```
erikas@zen:~/Projects/test$ cat test.php 
<?php

require_once 'WebToPay.php';


explainResult(WebToPay::getPaymentMethodList(6028, null, 'EUR'));
explainResult(WebToPay::getPaymentMethodList(6028, 0, 'EUR'));
explainResult(WebToPay::getPaymentMethodList(6028, 100, 'EUR'));

function explainResult(WebToPay_PaymentMethodList $list): void
{
    printf("LT payment methods found: %d\n", count((array) $list->getCountry('lt')?->getPaymentMethods()));
}
erikas@zen:~/Projects/test$ php test.php 
LT payment methods found: 0
LT payment methods found: 0
LT payment methods found: 13
erikas@zen:~/Projects/test$
```

Why do we get zero payment methods when we filter by amount = null? Because https://www.paysera.com/new/api/paymentMethods/6028/currency:EUR/amount: (mind ":" at the end of URL) is equivalent to https://www.paysera.com/new/api/paymentMethods/6028/currency:EUR/amount:0 and, if we want to fetch all enabled payment methods, we should ditch amount filter completely:  https://www.paysera.com/new/api/paymentMethods/6028/currency:EUR 

Changes in this pull request do exactly this. How library works with my test script above after my changes:

```
erikas@zen:~/Projects/test$ php test.php 
LT payment methods found: 16
LT payment methods found: 0
LT payment methods found: 13
erikas@zen:~/Projects/test$
```
