### PR TITLE
Change default parameter type in getAsString method

### DIFF
--- a/src/WebToPay/Config/Provider/EnvReader.php
+++ b/src/WebToPay/Config/Provider/EnvReader.php
@@ -14,7 +14,7 @@ class WebToPay_EnvReader
      * @param string|null $default
      * @return string|null
      */
-    public function getAsString(string $key, string $default = null): ?string
+    public function getAsString(string $key, ?string $default = null): ?string
     {
         if (!empty($_ENV[$key])) {
             return (string)$_ENV[$key];


### PR DESCRIPTION
Fixes #32

Implicitly marking parameter $default as nullable is deprecated, the explicit nullable type must be used instead