### PR TITLE
Fix/webclient empty response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Version history
 ===============
+Version 3.1.6 - 2026-07-14
+    * Throw a catchable WebToPayException when the HTTP response has no header separator, instead of a fatal TypeError on PHP 8
+
 Version 3.1.5 - 2025-08-04
     * Update payment methods endpoint url
 

--- a/WebToPay.php
+++ b/WebToPay.php
@@ -38,7 +38,7 @@ class WebToPay
     /**
      * WebToPay Library version.
      */
-    public const VERSION = '3.1.5';
+    public const VERSION = '3.1.6';
 
     /**
      * Server URL where all requests should go.

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "webtopay/libwebtopay",
     "description": "PHP Library for Paysera payment gateway integration",
-    "version": "3.1.5",
+    "version": "3.1.6",
     "license": "LGPL-3.0",
     "authors": [
         {

--- a/src/WebToPay/WebClient.php
+++ b/src/WebToPay/WebClient.php
@@ -49,15 +49,16 @@ class WebToPay_WebClient
 
         $content = $this->getContentFromSocket($fp, $out);
 
-        if (strpos($content, "\r\n\r\n") === false) {
+        // Separate header and content
+        $parts = explode("\r\n\r\n", $content, 2);
+        if (count($parts) < 2) {
             throw new WebToPayException(
                 sprintf('Cannot read response from %s', $uri),
                 WebToPayException::E_INVALID
             );
         }
 
-        // Separate header and content
-        [$header, $content] = explode("\r\n\r\n", $content, 2);
+        [$header, $content] = $parts;
 
         return trim($content);
     }

--- a/src/WebToPay/WebClient.php
+++ b/src/WebToPay/WebClient.php
@@ -49,6 +49,13 @@ class WebToPay_WebClient
 
         $content = $this->getContentFromSocket($fp, $out);
 
+        if (strpos($content, "\r\n\r\n") === false) {
+            throw new WebToPayException(
+                sprintf('Cannot read response from %s', $uri),
+                WebToPayException::E_INVALID
+            );
+        }
+
         // Separate header and content
         [$header, $content] = explode("\r\n\r\n", $content, 2);
 

--- a/tests/WebToPay/WebClientTest.php
+++ b/tests/WebToPay/WebClientTest.php
@@ -93,6 +93,8 @@ class WebToPay_WebClientTest extends TestCase
             ->willReturn($content);
 
         $this->expectException(WebToPayException::class);
+        $this->expectExceptionCode(WebToPayException::E_INVALID);
+        $this->expectExceptionMessage('Cannot read response from https://example.com');
         $this->webClientMock->get('https://example.com');
     }
 }

--- a/tests/WebToPay/WebClientTest.php
+++ b/tests/WebToPay/WebClientTest.php
@@ -72,4 +72,27 @@ class WebToPay_WebClientTest extends TestCase
             $this->webClientMock->get($uri, ['param1' => 'value1', 'param2' => 'value2'])
         );
     }
+
+    public function getResponsesWithoutHeaderSeparator(): iterable
+    {
+        yield 'empty response' => ['content' => ''];
+        yield 'truncated headers' => ['content' => "HTTP/1.1 200 OK\r\nContent-Type: text/xml"];
+    }
+
+    /**
+     * @dataProvider getResponsesWithoutHeaderSeparator
+     */
+    public function testGet_ThrowsOnResponseWithoutHeaderSeparator(string $content)
+    {
+        $this->webClientMock->expects($this->once())
+            ->method('openSocket')
+            ->willReturn('socket');
+
+        $this->webClientMock->expects($this->once())
+            ->method('getContentFromSocket')
+            ->willReturn($content);
+
+        $this->expectException(WebToPayException::class);
+        $this->webClientMock->get('https://example.com');
+    }
 }


### PR DESCRIPTION
 ## Problem

  `WebToPay_WebClient::get()` reads the response from a raw socket and splits
  headers from body with `explode("\r\n\r\n", $content, 2)`, then returns
  `trim($content)`.

  When the response is empty or cut off before the headers complete, there is
  no `\r\n\r\n` separator. `explode()` then returns a one-element array, `$content`
  becomes `null`, and on PHP 8 `trim(null)` raises a fatal `TypeError`. Since it is
  a `TypeError` (not a `WebToPayException`), the library's own error handling and
  downstream callers cannot catch it.

  ## Fix
  
  Validate the response before destructuring: if `\r\n\r\n` is absent, throw a
  `WebToPayException` with `E_INVALID`, consistent with the existing connection-failure
  handling in the same method. A transient/empty/truncated response now surfaces as a
  catchable library exception instead of a fatal error.

  ## Tests
  Added a data-provider test in `WebClientTest` covering an empty response and a
  response with truncated headers (no separator) — both now expect a `WebToPayException`.
  Existing happy-path and no-socket tests remain green. 
  
  ## Release
  
  Bumped version to `3.1.6` (`WebToPay::VERSION`, `composer.json`) and added a
  `CHANGELOG.md` entry.